### PR TITLE
build: upgrade idscan android sdks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // IDScan dependencies
-    implementation 'net.idscan.components.android:dlparser-standard:1.28.4'
-    implementation 'net.idscan.components.android:multiscan:2.0.0'
-    implementation 'net.idscan.components.android:multiscan-mrz:2.0.0'
-    implementation 'net.idscan.components.android:multiscan-pdf417:2.0.0'
+    implementation 'net.idscan.components.android:dlparser-standard:1.29.0'
+    implementation 'net.idscan.components.android:multiscan:2.3.1'
+    implementation 'net.idscan.components.android:multiscan-mrz:2.3.1'
+    implementation 'net.idscan.components.android:multiscan-pdf417:2.3.1'
     implementation "org.jetbrains.kotlin:kotlin-reflect"
 }


### PR DESCRIPTION
Its incredibly difficult to figure out if SDKs are up to date. You get 0 information from IDScan, their docs are wrong and repos outdated.

Their Maven provider does not have listing enabled so you have to guess. So I emailed them.

> I have asked the iOS team to confirm the latest. Android parser is 1.29.0 for the DLParser and all  multiscan components are  2.3.1

They never provided updated iOS binaries, so this is a version jump for Android side.